### PR TITLE
Add Quality Control Rush minigame for replayability

### DIFF
--- a/games/idle_factory.html
+++ b/games/idle_factory.html
@@ -813,6 +813,339 @@
             color: var(--text-dim);
         }
 
+        /* Quality Control Minigame */
+        .minigame-btn {
+            background: linear-gradient(135deg, var(--bg-card), var(--bg-panel));
+            border: 2px solid var(--warning);
+            color: var(--warning);
+            padding: 12px 24px;
+            font-family: 'Orbitron', sans-serif;
+            font-size: 0.85rem;
+            cursor: pointer;
+            margin-left: 16px;
+            transition: all 0.2s;
+            position: relative;
+            overflow: hidden;
+        }
+
+        .minigame-btn:hover:not(:disabled) {
+            background: var(--warning);
+            color: var(--bg-dark);
+            box-shadow: 0 0 20px rgba(210, 153, 34, 0.4);
+        }
+
+        .minigame-btn:disabled {
+            opacity: 0.5;
+            cursor: not-allowed;
+            border-color: var(--border);
+            color: var(--text-dim);
+        }
+
+        .minigame-btn .cooldown-bar {
+            position: absolute;
+            bottom: 0;
+            left: 0;
+            height: 3px;
+            background: var(--accent);
+            transition: width 0.1s linear;
+        }
+
+        .minigame-overlay {
+            position: fixed;
+            inset: 0;
+            background: var(--bg-dark);
+            z-index: 1000;
+            display: none;
+            flex-direction: column;
+        }
+
+        .minigame-overlay.active {
+            display: flex;
+        }
+
+        .minigame-header {
+            background: var(--bg-panel);
+            padding: 16px;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            border-bottom: 2px solid var(--border);
+        }
+
+        .minigame-title {
+            font-family: 'Orbitron', sans-serif;
+            font-size: 1.2rem;
+            color: var(--warning);
+        }
+
+        .minigame-stats {
+            display: flex;
+            gap: 24px;
+            font-family: 'Orbitron', sans-serif;
+        }
+
+        .minigame-stat {
+            text-align: center;
+        }
+
+        .minigame-stat-label {
+            font-size: 10px;
+            color: var(--text-dim);
+            text-transform: uppercase;
+        }
+
+        .minigame-stat-value {
+            font-size: 1.5rem;
+            color: var(--text-bright);
+        }
+
+        .minigame-stat-value.time {
+            color: var(--warning);
+        }
+
+        .minigame-stat-value.score {
+            color: var(--success);
+        }
+
+        .minigame-area {
+            flex: 1;
+            position: relative;
+            overflow: hidden;
+            background:
+                repeating-linear-gradient(
+                    90deg,
+                    transparent,
+                    transparent 80px,
+                    rgba(88, 166, 255, 0.05) 80px,
+                    rgba(88, 166, 255, 0.05) 82px
+                ),
+                var(--bg-dark);
+        }
+
+        .conveyor-lane {
+            position: absolute;
+            left: 0;
+            right: 0;
+            height: 80px;
+            background: linear-gradient(
+                180deg,
+                var(--bg-panel) 0%,
+                var(--bg-card) 20%,
+                var(--bg-card) 80%,
+                var(--bg-panel) 100%
+            );
+            border-top: 2px solid var(--border);
+            border-bottom: 2px solid var(--border);
+        }
+
+        .conveyor-lane::before {
+            content: '';
+            position: absolute;
+            inset: 0;
+            background: repeating-linear-gradient(
+                90deg,
+                transparent,
+                transparent 30px,
+                rgba(0,0,0,0.2) 30px,
+                rgba(0,0,0,0.2) 32px
+            );
+            animation: conveyorMove 1s linear infinite;
+        }
+
+        @keyframes conveyorMove {
+            from { transform: translateX(0); }
+            to { transform: translateX(32px); }
+        }
+
+        .minigame-item {
+            position: absolute;
+            width: 60px;
+            height: 60px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-size: 36px;
+            cursor: pointer;
+            transition: transform 0.1s;
+            border-radius: 8px;
+            user-select: none;
+            -webkit-user-select: none;
+        }
+
+        .minigame-item.good {
+            background: rgba(63, 185, 80, 0.2);
+            border: 2px solid var(--success);
+            animation: itemGlow 1s ease-in-out infinite;
+        }
+
+        .minigame-item.bad {
+            background: rgba(248, 81, 73, 0.2);
+            border: 2px solid var(--danger);
+            animation: itemShake 0.3s ease-in-out infinite;
+        }
+
+        @keyframes itemGlow {
+            0%, 100% { box-shadow: 0 0 10px rgba(63, 185, 80, 0.3); }
+            50% { box-shadow: 0 0 20px rgba(63, 185, 80, 0.6); }
+        }
+
+        @keyframes itemShake {
+            0%, 100% { transform: translateX(0) rotate(0deg); }
+            25% { transform: translateX(-2px) rotate(-2deg); }
+            75% { transform: translateX(2px) rotate(2deg); }
+        }
+
+        .minigame-item:active {
+            transform: scale(0.9);
+        }
+
+        .minigame-item.clicked {
+            animation: itemPop 0.3s ease-out forwards;
+        }
+
+        @keyframes itemPop {
+            0% { transform: scale(1); opacity: 1; }
+            50% { transform: scale(1.3); }
+            100% { transform: scale(0); opacity: 0; }
+        }
+
+        .minigame-feedback {
+            position: absolute;
+            font-family: 'Orbitron', sans-serif;
+            font-size: 1.5rem;
+            font-weight: bold;
+            pointer-events: none;
+            animation: feedbackFloat 0.8s ease-out forwards;
+        }
+
+        .minigame-feedback.good {
+            color: var(--success);
+        }
+
+        .minigame-feedback.bad {
+            color: var(--danger);
+        }
+
+        @keyframes feedbackFloat {
+            0% { transform: translateY(0) scale(1); opacity: 1; }
+            100% { transform: translateY(-50px) scale(1.5); opacity: 0; }
+        }
+
+        .minigame-results {
+            position: absolute;
+            inset: 0;
+            background: rgba(13, 17, 23, 0.95);
+            display: none;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            gap: 20px;
+        }
+
+        .minigame-results.active {
+            display: flex;
+        }
+
+        .minigame-results h2 {
+            font-family: 'Orbitron', sans-serif;
+            font-size: 2rem;
+            margin: 0;
+        }
+
+        .minigame-results.bronze h2 { color: #cd7f32; }
+        .minigame-results.silver h2 { color: #c0c0c0; }
+        .minigame-results.gold h2 { color: #ffd700; }
+        .minigame-results.perfect h2 { color: #ff6b9d; text-shadow: 0 0 20px #ff6b9d; }
+
+        .minigame-reward {
+            background: var(--bg-panel);
+            border: 1px solid var(--border);
+            padding: 20px 40px;
+            text-align: center;
+        }
+
+        .minigame-reward-label {
+            font-size: 12px;
+            color: var(--text-dim);
+            margin-bottom: 8px;
+        }
+
+        .minigame-reward-value {
+            font-family: 'Orbitron', sans-serif;
+            font-size: 1.5rem;
+            color: var(--success);
+        }
+
+        .minigame-close {
+            background: var(--accent);
+            border: none;
+            color: var(--bg-dark);
+            padding: 12px 32px;
+            font-family: 'Orbitron', sans-serif;
+            font-size: 1rem;
+            cursor: pointer;
+            margin-top: 20px;
+        }
+
+        .minigame-close:hover {
+            background: var(--text-bright);
+        }
+
+        .minigame-instructions {
+            position: absolute;
+            inset: 0;
+            background: rgba(13, 17, 23, 0.9);
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            gap: 16px;
+            text-align: center;
+            padding: 20px;
+        }
+
+        .minigame-instructions h3 {
+            font-family: 'Orbitron', sans-serif;
+            color: var(--warning);
+            margin: 0;
+        }
+
+        .minigame-instructions p {
+            color: var(--text);
+            max-width: 400px;
+            line-height: 1.6;
+        }
+
+        .minigame-legend {
+            display: flex;
+            gap: 30px;
+            margin: 10px 0;
+        }
+
+        .minigame-legend-item {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+        }
+
+        .minigame-legend-item.good { color: var(--success); }
+        .minigame-legend-item.bad { color: var(--danger); }
+
+        .minigame-start {
+            background: var(--warning);
+            border: none;
+            color: var(--bg-dark);
+            padding: 16px 48px;
+            font-family: 'Orbitron', sans-serif;
+            font-size: 1.1rem;
+            cursor: pointer;
+            margin-top: 10px;
+        }
+
+        .minigame-start:hover {
+            background: #e5ac26;
+        }
+
         /* Touch optimizations */
         button, .buy-btn, .upgrade, .building-icon, .tab {
             touch-action: manipulation;
@@ -930,7 +1263,62 @@
             🔧 FABRICATE
             <span class="label" id="clickVal">+1 per click</span>
         </button>
+        <button class="minigame-btn" id="minigameBtn" title="Quality Control Rush">
+            🎯 QC RUSH
+            <div class="cooldown-bar" id="cooldownBar"></div>
+        </button>
     </section>
+
+    <!-- Quality Control Minigame -->
+    <div class="minigame-overlay" id="minigameOverlay">
+        <header class="minigame-header">
+            <div class="minigame-title">⚡ QUALITY CONTROL RUSH</div>
+            <div class="minigame-stats">
+                <div class="minigame-stat">
+                    <div class="minigame-stat-label">Time</div>
+                    <div class="minigame-stat-value time" id="mgTime">30</div>
+                </div>
+                <div class="minigame-stat">
+                    <div class="minigame-stat-label">Score</div>
+                    <div class="minigame-stat-value score" id="mgScore">0</div>
+                </div>
+                <div class="minigame-stat">
+                    <div class="minigame-stat-label">Combo</div>
+                    <div class="minigame-stat-value" id="mgCombo">x1</div>
+                </div>
+            </div>
+        </header>
+        <div class="minigame-area" id="minigameArea">
+            <div class="minigame-instructions" id="mgInstructions">
+                <h3>🏭 QUALITY CONTROL</h3>
+                <p>Components are rolling off the production line! Tap the <strong>GOOD</strong> parts to earn points. Avoid the <strong>DEFECTIVE</strong> ones!</p>
+                <div class="minigame-legend">
+                    <div class="minigame-legend-item good">
+                        <span>🔩⚙️🔧</span>
+                        <span>= TAP!</span>
+                    </div>
+                    <div class="minigame-legend-item bad">
+                        <span>💥⚠️🔥</span>
+                        <span>= AVOID!</span>
+                    </div>
+                </div>
+                <p>Build combos for bonus points. Higher scores = better rewards!</p>
+                <button class="minigame-start" id="mgStart">START INSPECTION</button>
+            </div>
+            <div class="minigame-results" id="mgResults">
+                <h2 id="mgRank">GOLD RANK</h2>
+                <div class="minigame-stat">
+                    <div class="minigame-stat-label">Final Score</div>
+                    <div class="minigame-stat-value score" id="mgFinalScore">0</div>
+                </div>
+                <div class="minigame-reward">
+                    <div class="minigame-reward-label">Rewards</div>
+                    <div class="minigame-reward-value" id="mgReward">+1,000 🔩</div>
+                </div>
+                <button class="minigame-close" id="mgClose">COLLECT & EXIT</button>
+            </div>
+        </div>
+    </div>
 
     <nav class="tabs">
         <button class="tab active" data-tab="buildings">Buildings</button>
@@ -1251,6 +1639,12 @@
 
         { id: 's1', name: 'Night Owl', icon: '🦉', tier: 2, desc: 'Play at 3 AM', bonus: 0.05, check: () => new Date().getHours() === 3, hidden: true },
         { id: 's2', name: 'Speedrun', icon: '⚡', tier: 3, desc: '1M in 10 min', bonus: 0.1, check: () => g.totalComp.gte(1e6) && g.playTime < 600, hidden: true },
+
+        // QC Rush achievements
+        { id: 'qc1', name: 'Inspector', icon: '🎯', tier: 1, desc: 'Complete QC Rush', bonus: 0.02, check: () => mgState.bestScore > 0 },
+        { id: 'qc2', name: 'Sharp Eye', icon: '🎯', tier: 2, desc: 'Score 150 in QC', bonus: 0.03, check: () => mgState.bestScore >= 150 },
+        { id: 'qc3', name: 'Quality Master', icon: '🎯', tier: 3, desc: 'Score 300 in QC', bonus: 0.05, check: () => mgState.bestScore >= 300 },
+        { id: 'qc4', name: 'Perfect QC', icon: '🌟', tier: 3, desc: 'Score 500 in QC', bonus: 0.1, check: () => mgState.bestScore >= 500, hidden: true },
     ];
 
     // Game State
@@ -1735,6 +2129,7 @@
             ['Blueprints', g.bp],
             ['Blueprint Bonus', '+' + g.bp + '%'],
             ['Prestiges', g.prestiges],
+            ['QC Rush Best', mgState.bestScore],
             ['Play Time', fmtTime(g.playTime)],
             ['Offline Time', fmtTime(g.offlineTime)],
             ['Golden Gears', g.goldenClicks],
@@ -1856,6 +2251,8 @@
             lifeComp: g.lifeComp.toString(),
             highComp: g.highComp.toString(),
             lastSave: Date.now(),
+            mgBestScore: mgState.bestScore,
+            mgCooldownEnd: mgState.cooldownEnd,
         };
         try {
             localStorage.setItem('idleFactory', JSON.stringify(data));
@@ -1892,6 +2289,10 @@
             g.fastestReset = data.fastestReset || Infinity;
 
             BUILDINGS.forEach(b => { if (g.buildings[b.id] === undefined) g.buildings[b.id] = 0; });
+
+            // Load minigame state
+            mgState.bestScore = data.mgBestScore || 0;
+            mgState.cooldownEnd = data.mgCooldownEnd || 0;
 
             audio.setVol(g.settings.vol);
             audio.muted = g.settings.muted;
@@ -2024,10 +2425,323 @@
         if (g.totalComp.gt(g.highComp)) g.highComp = g.totalComp;
     }
 
+    // ============================================
+    // QUALITY CONTROL MINIGAME
+    // ============================================
+
+    const MINIGAME = {
+        DURATION: 30,           // seconds
+        COOLDOWN: 180,          // seconds (3 minutes)
+        SPAWN_RATE: 800,        // ms between spawns (gets faster)
+        GOOD_ITEMS: ['🔩', '⚙️', '🔧', '🔨', '⛏️', '🛠️'],
+        BAD_ITEMS: ['💥', '⚠️', '🔥', '💀', '☠️', '🚫'],
+        LANES: 4,
+        ITEM_SPEED: 3,          // seconds to cross screen
+    };
+
+    let mgState = {
+        active: false,
+        score: 0,
+        combo: 1,
+        maxCombo: 1,
+        timeLeft: MINIGAME.DURATION,
+        items: [],
+        spawnTimer: null,
+        gameTimer: null,
+        tickTimer: null,
+        cooldownEnd: 0,
+        bestScore: 0,
+    };
+
+    function openMinigame() {
+        if (Date.now() < mgState.cooldownEnd) return;
+
+        document.getElementById('minigameOverlay').classList.add('active');
+        document.getElementById('mgInstructions').style.display = 'flex';
+        document.getElementById('mgResults').classList.remove('active');
+
+        // Reset state
+        mgState.active = false;
+        mgState.score = 0;
+        mgState.combo = 1;
+        mgState.maxCombo = 1;
+        mgState.timeLeft = MINIGAME.DURATION;
+        mgState.items = [];
+
+        updateMinigameUI();
+    }
+
+    function startMinigame() {
+        document.getElementById('mgInstructions').style.display = 'none';
+        mgState.active = true;
+
+        // Create conveyor lanes
+        const area = document.getElementById('minigameArea');
+        const areaHeight = area.clientHeight;
+        const laneHeight = 80;
+        const totalLanesHeight = MINIGAME.LANES * laneHeight;
+        const startY = (areaHeight - totalLanesHeight) / 2;
+
+        // Clear old lanes
+        area.querySelectorAll('.conveyor-lane').forEach(l => l.remove());
+
+        for (let i = 0; i < MINIGAME.LANES; i++) {
+            const lane = document.createElement('div');
+            lane.className = 'conveyor-lane';
+            lane.style.top = (startY + i * laneHeight) + 'px';
+            area.appendChild(lane);
+        }
+
+        // Start spawning
+        spawnMinigameItem();
+        mgState.spawnTimer = setInterval(() => {
+            if (mgState.active) spawnMinigameItem();
+        }, MINIGAME.SPAWN_RATE);
+
+        // Start timer
+        mgState.tickTimer = setInterval(() => {
+            if (!mgState.active) return;
+            mgState.timeLeft -= 0.1;
+            updateMinigameUI();
+
+            if (mgState.timeLeft <= 0) {
+                endMinigame();
+            }
+        }, 100);
+
+        // Speed up spawns over time
+        mgState.gameTimer = setInterval(() => {
+            if (!mgState.active) return;
+            clearInterval(mgState.spawnTimer);
+            const newRate = Math.max(300, MINIGAME.SPAWN_RATE - (MINIGAME.DURATION - mgState.timeLeft) * 15);
+            mgState.spawnTimer = setInterval(() => {
+                if (mgState.active) spawnMinigameItem();
+            }, newRate);
+        }, 5000);
+
+        audio.init();
+    }
+
+    function spawnMinigameItem() {
+        const area = document.getElementById('minigameArea');
+        const areaHeight = area.clientHeight;
+        const laneHeight = 80;
+        const totalLanesHeight = MINIGAME.LANES * laneHeight;
+        const startY = (areaHeight - totalLanesHeight) / 2;
+
+        const isGood = Math.random() > 0.35; // 65% good, 35% bad
+        const lane = Math.floor(Math.random() * MINIGAME.LANES);
+        const items = isGood ? MINIGAME.GOOD_ITEMS : MINIGAME.BAD_ITEMS;
+        const icon = items[Math.floor(Math.random() * items.length)];
+
+        const item = document.createElement('div');
+        item.className = 'minigame-item ' + (isGood ? 'good' : 'bad');
+        item.textContent = icon;
+        item.dataset.good = isGood;
+        item.style.left = '-70px';
+        item.style.top = (startY + lane * laneHeight + 10) + 'px';
+
+        // Animate across screen
+        const speed = MINIGAME.ITEM_SPEED - (MINIGAME.DURATION - mgState.timeLeft) * 0.03;
+        item.style.transition = `left ${Math.max(1.5, speed)}s linear`;
+
+        const handleClick = (e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            if (item.classList.contains('clicked')) return;
+
+            item.classList.add('clicked');
+            const rect = item.getBoundingClientRect();
+
+            if (isGood) {
+                // Good item clicked = points!
+                const points = 10 * mgState.combo;
+                mgState.score += points;
+                mgState.combo = Math.min(mgState.combo + 1, 10);
+                mgState.maxCombo = Math.max(mgState.maxCombo, mgState.combo);
+                showMinigameFeedback(rect.left + 30, rect.top, '+' + points, 'good');
+                audio.click();
+            } else {
+                // Bad item clicked = penalty!
+                mgState.score = Math.max(0, mgState.score - 20);
+                mgState.combo = 1;
+                showMinigameFeedback(rect.left + 30, rect.top, '-20', 'bad');
+                audio.prestige(); // Use prestige sound as "error"
+            }
+
+            updateMinigameUI();
+            setTimeout(() => item.remove(), 300);
+        };
+
+        item.onclick = handleClick;
+        item.ontouchend = handleClick;
+
+        area.appendChild(item);
+
+        // Start animation after append
+        requestAnimationFrame(() => {
+            item.style.left = (area.clientWidth + 70) + 'px';
+        });
+
+        // Remove when off screen and penalize missed good items
+        setTimeout(() => {
+            if (!item.classList.contains('clicked') && item.parentNode) {
+                if (isGood) {
+                    // Missed a good item!
+                    mgState.combo = 1;
+                }
+                item.remove();
+            }
+        }, (Math.max(1.5, speed) + 0.5) * 1000);
+    }
+
+    function showMinigameFeedback(x, y, text, type) {
+        const fb = document.createElement('div');
+        fb.className = 'minigame-feedback ' + type;
+        fb.textContent = text;
+        fb.style.left = x + 'px';
+        fb.style.top = y + 'px';
+        document.getElementById('minigameArea').appendChild(fb);
+        setTimeout(() => fb.remove(), 800);
+    }
+
+    function updateMinigameUI() {
+        document.getElementById('mgTime').textContent = Math.ceil(mgState.timeLeft);
+        document.getElementById('mgScore').textContent = mgState.score;
+        document.getElementById('mgCombo').textContent = 'x' + mgState.combo;
+
+        // Update combo color based on value
+        const comboEl = document.getElementById('mgCombo');
+        if (mgState.combo >= 8) {
+            comboEl.style.color = '#ff6b9d';
+        } else if (mgState.combo >= 5) {
+            comboEl.style.color = '#ffd700';
+        } else if (mgState.combo >= 3) {
+            comboEl.style.color = '#3fb950';
+        } else {
+            comboEl.style.color = '';
+        }
+
+        // Update cooldown bar
+        updateCooldownBar();
+    }
+
+    function updateCooldownBar() {
+        const now = Date.now();
+        const btn = document.getElementById('minigameBtn');
+        const bar = document.getElementById('cooldownBar');
+
+        if (now < mgState.cooldownEnd) {
+            const remaining = mgState.cooldownEnd - now;
+            const total = MINIGAME.COOLDOWN * 1000;
+            const pct = (remaining / total) * 100;
+            bar.style.width = (100 - pct) + '%';
+            btn.disabled = true;
+            btn.title = `Cooldown: ${Math.ceil(remaining / 1000)}s`;
+        } else {
+            bar.style.width = '100%';
+            btn.disabled = false;
+            btn.title = 'Quality Control Rush';
+        }
+    }
+
+    function endMinigame() {
+        mgState.active = false;
+        clearInterval(mgState.spawnTimer);
+        clearInterval(mgState.gameTimer);
+        clearInterval(mgState.tickTimer);
+
+        // Clear remaining items
+        document.querySelectorAll('.minigame-item').forEach(i => i.remove());
+
+        // Determine rank and rewards
+        const score = mgState.score;
+        let rank, rankClass, compReward, multiplier, duration, bpChance;
+
+        if (score >= 500) {
+            rank = '🌟 PERFECT INSPECTOR';
+            rankClass = 'perfect';
+            compReward = prodPerSec().mul(180); // 3 min production
+            multiplier = 3;
+            duration = 120;
+            bpChance = 0.25;
+        } else if (score >= 300) {
+            rank = '🥇 GOLD RANK';
+            rankClass = 'gold';
+            compReward = prodPerSec().mul(120); // 2 min production
+            multiplier = 2;
+            duration = 90;
+            bpChance = 0.1;
+        } else if (score >= 150) {
+            rank = '🥈 SILVER RANK';
+            rankClass = 'silver';
+            compReward = prodPerSec().mul(60); // 1 min production
+            multiplier = 1.5;
+            duration = 60;
+            bpChance = 0;
+        } else {
+            rank = '🥉 BRONZE RANK';
+            rankClass = 'bronze';
+            compReward = prodPerSec().mul(30); // 30s production
+            multiplier = 1.25;
+            duration = 30;
+            bpChance = 0;
+        }
+
+        // Apply rewards
+        if (compReward.lt(100)) compReward = D(100); // Minimum reward
+        g.comp = g.comp.add(compReward);
+        g.totalComp = g.totalComp.add(compReward);
+        g.lifeComp = g.lifeComp.add(compReward);
+
+        // Production boost
+        g.activeBonus = 'prod';
+        g.bonusEnd = Date.now() + duration * 1000;
+
+        // Chance for blueprint
+        let bpGained = 0;
+        if (Math.random() < bpChance) {
+            bpGained = 1;
+            g.bp += 1;
+        }
+
+        // Update best score
+        if (score > mgState.bestScore) mgState.bestScore = score;
+
+        // Show results
+        const results = document.getElementById('mgResults');
+        results.className = 'minigame-results active ' + rankClass;
+        document.getElementById('mgRank').textContent = rank;
+        document.getElementById('mgFinalScore').textContent = score;
+
+        let rewardText = `+${fmt(compReward)} 🔩\n${multiplier}x prod for ${duration}s`;
+        if (bpGained > 0) rewardText += '\n+1 📐 BLUEPRINT!';
+        document.getElementById('mgReward').innerHTML = rewardText.replace(/\n/g, '<br>');
+
+        // Set cooldown
+        mgState.cooldownEnd = Date.now() + MINIGAME.COOLDOWN * 1000;
+
+        audio.upgrade();
+    }
+
+    function closeMinigame() {
+        document.getElementById('minigameOverlay').classList.remove('active');
+        document.querySelectorAll('.conveyor-lane').forEach(l => l.remove());
+        updateResources();
+    }
+
     // Event Setup
     function setup() {
         document.getElementById('mainBtn').onclick = doClick;
         document.getElementById('mainBtn').ontouchstart = (e) => { e.preventDefault(); doClick(e); };
+
+        // Minigame button
+        document.getElementById('minigameBtn').onclick = openMinigame;
+        document.getElementById('mgStart').onclick = startMinigame;
+        document.getElementById('mgClose').onclick = closeMinigame;
+
+        // Update cooldown bar periodically
+        setInterval(updateCooldownBar, 1000);
 
         document.getElementById('saveBtn').onclick = save;
         document.getElementById('muteBtn').onclick = () => {


### PR DESCRIPTION
New minigame accessible via "QC RUSH" button:
- 30-second timed challenge with conveyor belt aesthetic
- Tap good components (🔩⚙️🔧) for points, avoid defects (💥⚠️🔥)
- Combo system rewards consecutive good taps (up to 10x)
- Speed increases as time progresses for added challenge
- 4 reward tiers based on score:
  - Bronze (<150): 30s prod bonus, 1.25x multiplier
  - Silver (150+): 1min prod bonus, 1.5x multiplier
  - Gold (300+): 2min prod bonus, 2x multiplier, 10% BP chance
  - Perfect (500+): 3min prod bonus, 3x multiplier, 25% BP chance
- 3-minute cooldown between attempts
- Best score tracked in stats and persisted in save
- 4 new achievements for QC Rush mastery
- Full mobile touch support

This adds active, skill-based gameplay that breaks up the idle progression while fitting the factory theme perfectly.