### PR TITLE
Fix minigame z-index issues on mobile

### DIFF
--- a/games/idle_factory.html
+++ b/games/idle_factory.html
@@ -1223,6 +1223,7 @@
             left: 0;
             right: 0;
             height: 90px;
+            z-index: 1;
             background: linear-gradient(
                 180deg,
                 var(--bg-panel) 0%,
@@ -1257,6 +1258,7 @@
             position: absolute;
             width: 70px;
             height: 70px;
+            z-index: 10;
             display: flex;
             align-items: center;
             justify-content: center;
@@ -1317,6 +1319,7 @@
 
         .minigame-feedback {
             position: absolute;
+            z-index: 20;
             font-family: 'Orbitron', sans-serif;
             font-size: 1.5rem;
             font-weight: bold;
@@ -1340,6 +1343,7 @@
         .minigame-results {
             position: absolute;
             inset: 0;
+            z-index: 100;
             background: rgba(13, 17, 23, 0.95);
             display: none;
             flex-direction: column;


### PR DESCRIPTION
- Add z-index: 1 to conveyor lanes
- Add z-index: 10 to minigame items so they appear above lanes
- Add z-index: 20 to feedback floating text
- Add z-index: 100 to results overlay so it covers everything

Fixes items not visible and results appearing behind conveyor belts