### PR TITLE
Fix mobile layout issues: overflow and number width shifts

### DIFF
--- a/games/idle_factory.html
+++ b/games/idle_factory.html
@@ -43,6 +43,7 @@
             min-height: 100vh;
             line-height: 1.4;
             font-size: 14px;
+            overflow-x: hidden;
             background-image:
                 linear-gradient(rgba(88, 166, 255, 0.03) 1px, transparent 1px),
                 linear-gradient(90deg, rgba(88, 166, 255, 0.03) 1px, transparent 1px);
@@ -163,6 +164,8 @@
             color: var(--text-bright);
             font-variant-numeric: tabular-nums;
             transition: color 0.2s;
+            min-width: 100px;
+            text-align: left;
         }
 
         .resource.producing .resource-value {
@@ -861,6 +864,8 @@
             margin-bottom: 12px;
             padding-bottom: 8px;
             border-bottom: 1px solid var(--border);
+            flex-wrap: wrap;
+            gap: 8px;
         }
 
         .section-title {
@@ -1466,6 +1471,25 @@
         @media (max-width: 600px), (hover: none) {
             .resources {
                 grid-template-columns: 1fr 1fr;
+                margin: 8px;
+            }
+
+            .resource {
+                padding: 8px 10px;
+            }
+
+            .resource-value {
+                font-size: 1.1rem;
+                min-width: 80px;
+            }
+
+            .bulk-btn {
+                padding: 4px 6px;
+                font-size: 10px;
+            }
+
+            .section-header {
+                gap: 6px;
             }
 
             .building {


### PR DESCRIPTION
- Add overflow-x: hidden to body to prevent horizontal scroll
- Add min-width to resource values to prevent layout shifts
- Reduce margins and padding on mobile for resources
- Make bulk buy buttons smaller on mobile
- Add flex-wrap to section headers for narrow screens
- Reduce resource value font size on mobile