### PR TITLE
Fix prestige bar jump with overscroll-behavior and dvh

### DIFF
--- a/games/idle_factory.html
+++ b/games/idle_factory.html
@@ -36,14 +36,21 @@
             box-sizing: border-box;
         }
 
+        html {
+            overflow-x: hidden;
+            overscroll-behavior: none;
+        }
+
         body {
             font-family: 'JetBrains Mono', monospace;
             background: var(--bg-dark);
             color: var(--text);
             min-height: 100vh;
+            min-height: 100dvh;
             line-height: 1.4;
             font-size: 14px;
             overflow-x: hidden;
+            overscroll-behavior: none;
             background-image:
                 linear-gradient(rgba(88, 166, 255, 0.03) 1px, transparent 1px),
                 linear-gradient(90deg, rgba(88, 166, 255, 0.03) 1px, transparent 1px);


### PR DESCRIPTION
- Add overscroll-behavior: none to html and body to prevent scroll bounce
- Use 100dvh (dynamic viewport height) which accounts for mobile browser UI changes (address bar hiding/showing)
- This should prevent the fixed prestige bar from appearing to jump