### PR TITLE
Fix HUD text spilling out of the ability rail, and show objectives on…

### DIFF
--- a/games/timberbound.html
+++ b/games/timberbound.html
@@ -96,8 +96,13 @@
         #prompt{min-height:28px;padding:7px 13px;border-radius:99px;background:rgba(2,8,5,.78);border:1px solid rgba(255,255,255,.13);font:800 15px/1.2 ui-monospace,monospace;letter-spacing:.07em;opacity:0;transition:opacity .15s}
         #prompt.visible{opacity:1}
 
-        #ability-bar{position:absolute;right:18px;bottom:18px;display:grid;gap:7px;width:220px}
+        /* 236px, not 220: the label column has to hold the longest unbreakable title (EMBERWAKE)
+           beside the key and the LOCKED readout, or the card spills its text over the panel edge. */
+        #ability-bar{position:absolute;right:18px;bottom:18px;display:grid;gap:7px;width:236px}
         .ability{padding:9px 11px;border-radius:11px;display:grid;grid-template-columns:25px 1fr auto;gap:8px;align-items:center;opacity:.35}
+        /* Grid items default to min-width:auto, so the label column refused to shrink below its
+           longest line and pushed the card wider than the 220px rail, spilling text past the panel. */
+        .ability>div{min-width:0}
         .ability.unlocked{opacity:1}.ability .key{width:25px;height:25px;border-radius:6px;display:grid;place-items:center;background:rgba(255,255,255,.07);font:900 15px/1 ui-monospace,monospace}.ability b{font-size:15px}.ability small{display:block;color:var(--muted);font-size:13px;margin-top:2px}.ability output{font:900 15px/1 ui-monospace,monospace;color:var(--cyan)}
 
         #toast-stack{position:absolute;z-index:55;left:50%;top:26%;transform:translateX(-50%);display:grid;gap:8px;justify-items:center}
@@ -279,7 +284,7 @@
             /* Objective collapses to kicker + title + progress; the paragraph is menu-only. */
             body.touch-mode #objective{top:max(8px,env(safe-area-inset-top));right:max(66px,calc(env(safe-area-inset-right) + 66px));
                 width:min(236px,calc(var(--ui-vw) * .32));padding:7px 10px;opacity:.93}
-            body.touch-mode #objective .objective-copy{display:none}
+            body.touch-mode #objective .objective-copy{font-size:12px;line-height:1.35;margin-top:5px}
             body.touch-mode #objective-kicker{font-size:12px;letter-spacing:.16em}
             body.touch-mode #objective-title{font-size:14px;margin-top:4px;line-height:1.25}
             body.touch-mode #objective-progress{height:4px;margin-top:7px}


### PR DESCRIPTION
… touch

Two layout faults found by rendering the running game at real device viewports, which is something this project had never done.

The ability rail spilled its text over the panel edge. #ability-bar is a fixed 220px, and each card is a 25px / 1fr / auto grid. Grid items get min-width:auto by default, so the middle column could not shrink below its longest line and pushed the card's content to 227px inside a 220px box. Adding min-width:0 to the label column fixes the shrink, and the rail goes to 236px because the longest unbreakable title, EMBERWAKE, is about 108px against the 101px the old width left it. Measured after the change: every card 236px wide, no child within 2px of an edge.

Touch players could not see objective instructions at all. The copy is hidden by .objective-copy{display:none} inside
@media(pointer:coarse) and (orientation:landscape) -- which is the only mode a phone can play in, since portrait shows the rotate hint. The text was already written for touch: updateObjective() picks "Aim at a trunk and hold CHOP." over the left-mouse wording, and there is a second touch variant for the Mosswick objective. None of it could ever reach a player. It now shows at 12px; the longest copy is 100 characters and the box still fits 844x390 with no overflow.


Claude-Session: https://claude.ai/code/session_01SCR7jR1xSLmP4vrmuMUFAB