### PR TITLE
Add two verified stages and The Deep, an endless mode built on a solv…

### DIFF
--- a/IDEAS.md
+++ b/IDEAS.md
@@ -113,6 +113,34 @@ still exists at four lines — at least five of the 6,561, all leaning on a tric
 the same line twice in a row. Verify a stage has an answer before designing around it; two of the six shipped
 here changed shape because the search said no.
 
+A later pass asked whether it had room to grow, and the measuring is the useful part, because almost
+everything obvious turned out to be a dead end. Harder mazes do nothing: the wall-following rule is 200 of
+200 at 25×25 and 200 of 200 with a random start cell and random facing, so difficulty cannot come from the
+boards. An efficiency score is dead too — all 90 universal rulebooks of three and four lines average between
+38.6 and 38.8 steps to the goal, a spread of nothing, against a shortest route of 23.7 that a robot with no
+memory cannot reach. And new *worlds* mostly have no answers at all: one-way doors break the rule hard (12 of
+200) but have no rulebook up to five lines even when given a "the way back is shut" sense; ice tiles (173 of
+200) and spinner tiles (6 of 200) the same. That is three more stage ideas killed by search, on top of the
+loops stage killed earlier.
+
+What does work is the opposite of adding: take tools away. Keep the mazes and shrink the vocabulary, and
+answers keep existing at longer and longer lengths — full vocabulary 3 lines, no side senses 4, only
+wall-senses and no "open ahead" 5, no left turns 6, no side senses *and* no left turns 6. That generalises,
+which is the actual find: a stage is just a subset of the vocabulary, there are 1,023 of them, and
+solvability is monotone, so a subset's answer bounds every superset's. Processing subsets smallest-first and
+inheriting those bounds turns an impossible enumeration into 19 seconds of work, and yields the whole table:
+**163 of the 1,023 vocabularies can solve a maze at all**, with shortest rulebooks of 3 (38 of them), 4 (31),
+5 (9) and 6 (85) lines. Shipping that table is what lets the endless mode hand out a handicap and promise it
+can be beaten, and say in how many lines, without shipping any answers.
+
+Two mechanical notes worth reusing. The table only became affordable after the machine was reimplemented
+allocation-free — boards flattened to a Uint8Array of passable directions, and cycle detection against one
+reusable stamped buffer instead of a Set per run — which was about thirty times faster and, checked against
+the shipped engine over 480,000 runs, agrees on every one. The check earned its keep: the first version of it
+disagreed on 0.17% of runs because the condition indices were mapped in the wrong order, which no amount of
+staring would have caught. And the promise is verified against the boards the game actually generates, not
+the ones the table was built on — every one of 200 Deep rounds re-checked on its own 200 mazes.
+
 Filled since: **minigolf**, by `games/nine_holes.html`. Worth reusing are three results, all of which
 contradicted what the design assumed before it was measured.
 

--- a/data/games.json
+++ b/data/games.json
@@ -1728,7 +1728,7 @@
   {
     "id": "everywhere",
     "title": "Everywhere \u2014 write one rule that solves every maze",
-    "description": "A programming puzzle where you never solve a level. You write one short rulebook for a robot \u2014 plain if-then lines, read top to bottom and then repeated \u2014 and the game tests it against hundreds of mazes you have never seen, then shows you the one that beats it, with your robot's path drawn on it. Six stages take you from a straight corridor to the wall-following rule that solves every maze, then take your side senses away and make you rebuild it blind. Nothing is graded until it works everywhere.",
+    "description": "A programming puzzle where you never solve a level. You write one short rulebook for a robot \u2014 plain if-then lines, read top to bottom and then repeated \u2014 and the game tests it against hundreds of mazes you have never seen, then shows you the one that beats it, with your robot's path drawn on it. Eight stages take you from a straight corridor to the wall-following rule that solves every maze, then start taking the robot's senses away and make you rebuild it blind. Below them is The Deep, an endless run of handicaps drawn from an exhaustive table of which vocabularies can solve a maze at all \u2014 so every round is known to be beatable, and tells you in how many lines.",
     "url": "games/everywhere.html",
     "screenshot": "screenshots/screenshot_296.webp",
     "type": "game",

--- a/games/everywhere.html
+++ b/games/everywhere.html
@@ -28,7 +28,7 @@
   "name": "Everywhere",
   "url": "https://www.gptgames.dev/games/everywhere.html",
   "image": "https://www.gptgames.dev/screenshots/screenshot_306.webp",
-  "description": "A programming puzzle in which the player never solves a single level. The player writes one short rulebook of if-then rules for a robot, and the game tests that rulebook against two hundred freshly generated mazes, then shows the one that defeats it. Six stages escalate from a straight corridor to mazes with loops, where the classic wall-following rule provably fails.",
+  "description": "A programming puzzle in which the player never solves a single level. The player writes one short rulebook of if-then rules for a robot, and the game tests that rulebook against two hundred freshly generated mazes, then shows the one that defeats it. Eight stages escalate from a straight corridor to the wall-following rule and then strip the robot\u2019s senses away one at a time, followed by an endless mode whose handicaps are drawn from an exhaustively computed table of which vocabularies can solve a maze at all.",
   "genre": ["Puzzle", "Strategy", "Logic"],
   "gamePlatform": "Web Browser",
   "playMode": "SinglePlayer",
@@ -131,10 +131,15 @@ main{flex:1;display:flex;min-height:0;min-width:0}
   flex:0 0 auto;display:flex;align-items:center;gap:10px;
   padding:9px 16px;border-bottom:1px solid var(--line);background:var(--panel2);
 }
-#pips{display:flex;gap:5px}
+#pips{display:flex;gap:6px;align-items:center;flex:0 0 auto}
 .pip{width:22px;height:5px;border-radius:3px;background:var(--line2)}
 .pip.done{background:var(--good)}
 .pip.cur{background:var(--accent)}
+.depth{font-size:12.5px;color:var(--chalk);font-weight:700;letter-spacing:.06em;
+  border:1px solid var(--line2);border-radius:6px;padding:2px 8px}
+.parchip{font-size:12px;color:var(--chalk);border:1px solid var(--line2);
+  border-radius:6px;padding:2px 8px;white-space:nowrap}
+@media (max-width:860px){ .parchip{font-size:11px;padding:2px 6px} }
 #brief{font-size:13px;color:var(--dim);flex:1;min-width:0}
 #stuckBtn{flex:0 0 auto}
 #brief b{color:var(--ink);font-weight:600}
@@ -706,6 +711,31 @@ const STAGES=[
   newbits:"Everything you built the last rule on is gone from the list. It can still be done, in <b>four lines</b> — there are at least five such rulebooks among the 6,561, and they all lean on a trick you have not needed yet: <b>the same line, twice in a row</b>."
 },
 {
+  id:"stone", name:"The Stone",
+  hints:["You can feel stone, never space. But there are only two possibilities, so a wall you cannot feel is an opening.",
+         "You have no way to say <b>open ahead</b> any more — but a line that fires on <b>wall ahead</b> can turn you, and the line after it sees the result.",
+         "Five lines. Turn away from the wall on your right until it is gone, then walk: <b>wall right → turn left</b> three times over, then <b>always → turn right</b>, then <b>always → step forward</b>."],
+  brief:"You can feel walls. You can no longer feel openings.",
+  gen:s=>genMaze(s,7,7),
+  conds:["ALWAYS","WALL_AHEAD","WALL_RIGHT","WALL_LEFT"], acts:["STEP","RIGHT","LEFT"], slots:6, trial:200,
+  title:"The Stone",
+  blurb:"Every sense you had for open ground is gone. The robot can tell you where the stone is and nothing else — and a rule that steps forward without being sure the way is clear will walk into it.",
+  newbits:"The mazes are the ones you already beat. Exhaustive search says this vocabulary still has an answer, and that the shortest is <b>five lines</b> — two longer than when you could see the gaps."
+},
+{
+  id:"ratchet", name:"The Ratchet",
+  hints:["The left actuator is dead. Everything you could do before, you can still do — it just costs more.",
+         "A left turn is three right turns. The question is where those three lines go so they do not fire when you did not want them to.",
+         "Six lines. Steer with three conditional right turns, then two unconditional ones, then step."],
+  brief:"Your senses are back. The robot can only turn right.",
+  gen:s=>genMaze(s,7,7),
+  conds:["ALWAYS","WALL_AHEAD","PATH_AHEAD","PATH_RIGHT","PATH_LEFT","WALL_RIGHT","WALL_LEFT"],
+  acts:["STEP","RIGHT"], slots:7, trial:200,
+  title:"The Ratchet",
+  blurb:"You get every sense back, and lose something simpler: the robot cannot turn left. It is still capable of everything it was — a left turn is just three right ones — but each one now costs you lines you may not have.",
+  newbits:"Shortest possible here is <b>six lines</b>, double the rule you started The Maze with. Every one of the 7,529,536 six-line rulebooks was checked to find that out."
+},
+{
   id:"everywhere", name:"Everywhere",
   hints:["Nothing new is needed. If your maze rule fails here, it was leaning on something about the mazes rather than about walls.",
          "Check it never assumes the goal is at the bottom right, and that it survives a corridor one tile wide.",
@@ -721,6 +751,73 @@ const STAGES=[
 ];
 
 /* ============================================================
+   The Deep — endless rounds, each one a handicap.
+
+   A round is a subset of the vocabulary. Before this shipped, every one of
+   the 1,023 subsets was searched exhaustively for the shortest rulebook that
+   solves 200 mazes, and the answer lengths are the string below: one digit
+   per vocabulary, indexed by condition-mask * 8 + action-mask, 0 where no
+   rulebook of seven lines or fewer exists. So the game only ever hands you a
+   handicap it has already proved can be beaten, and can tell you in how many
+   lines. It does not carry the answers, only their lengths.
+   ============================================================ */
+const TABLE="0000000000000000000000000000000500000000000000060000000000060604000000000000000600000000000000040000000000060604000000030006060300000000000000060000000000000004000000000006060400000003000606030000000000060606000000000006060400000000000606040000000300060603000000000000000500000000000000050000000000060604000000060006060400000000000000040000000000000004000000030006060300000003000606030000000000000005000000000000000400000000000606040000000300060603000000000006060400000000000606040000000300060603000000030006060300000000000000050000000000000005000000000006060400000006000606040000000000000005000000000000000400000000000606040000000300060603000000000000000400000000000000040000000300060603000000030006060300000000000606040000000000060604000000030006060300000003000606030000000000000005000000000000000500000000000606040000000600060604000000000000000400000000000000040000000300060603000000030006060300000000000000040000000000000004000000030006060300000003000606030000000000060604000000000006060400000003000606030000000300060603";
+const CONDS_ALL=["ALWAYS","WALL_AHEAD","PATH_AHEAD","PATH_RIGHT","PATH_LEFT","WALL_RIGHT","WALL_LEFT"];
+const ACTS_ALL=["STEP","RIGHT","LEFT"];
+const par=(cm,am)=>TABLE.charCodeAt(cm*8+am)-48;
+const popc=n=>{let c=0;while(n){c+=n&1;n>>=1;}return c;};
+
+/* the rounds worth playing: solvable, not trivial, and short enough to read */
+let DEEPPOOL=null;
+function deepPool(){
+  if(DEEPPOOL) return DEEPPOOL;
+  const out=[];
+  for(let cm=1;cm<128;cm++) for(let am=1;am<8;am++){
+    const L=par(cm,am);
+    if(L<4) continue;                       /* the ladder already covers these */
+    const nc=popc(cm), na=popc(am);
+    if(nc<2||nc>5) continue;                /* keep the two menus legible */
+    out.push({cm,am,L});
+  }
+  /* gentlest first, and a fixed order so everyone's Deep is the same Deep */
+  out.sort((a,b)=>a.L-b.L || (popc(a.cm)+popc(a.am))-(popc(b.cm)+popc(b.am)) || a.cm-b.cm || a.am-b.am);
+  return DEEPPOOL=out;
+}
+function deepRound(n){                       /* n counts from 1 */
+  const pool=deepPool();
+  if(!pool.length) return null;
+  const r=mulberry32(0x5eed+n*2654435761>>>0);
+  /* work up through the difficulty bands, then wander inside the hardest */
+  const bands={};
+  for(const v of pool) (bands[v.L]=bands[v.L]||[]).push(v);
+  const Ls=Object.keys(bands).map(Number).sort((a,b)=>a-b);
+  const band=Ls[Math.min(Ls.length-1,Math.floor((n-1)/3))];
+  const list=bands[band];
+  const v=list[(n*7+Math.floor(r()*list.length))%list.length];
+  const conds=CONDS_ALL.filter((_,i)=>v.cm&(1<<i));
+  const acts=ACTS_ALL.filter((_,i)=>v.am&(1<<i));
+  const lost=CONDS_ALL.filter((_,i)=>!(v.cm&(1<<i))).map(c=>C[c].text)
+        .concat(ACTS_ALL.filter((_,i)=>!(v.am&(1<<i))).map(a=>A[a].text));
+  return {
+    id:"deep"+n, deep:true, round:n, par:v.L,
+    name:"The Deep · "+n,
+    brief:"Gone: "+(lost.length?lost.join(", "):"nothing")+".",
+    gen:s=>genMaze(s,7,7),
+    conds,acts, slots:Math.min(8,v.L+2), trial:200,
+    hints:["Every round here has an answer — this one in "+v.L+" line"+(v.L>1?"s":"")+
+           ". Ask what the missing sense used to tell you, and what still can.",
+           "Anything you cannot sense directly you can often reach by turning to face it and looking, then turning back.",
+           "A line may appear twice. Two of the same turn in a row is a half circle, three is a turn the other way."],
+    title:"The Deep · round "+n,
+    blurb:"Same mazes. Fewer tools. "+(lost.length
+      ? "This round takes away "+lost.join(", ")+"."
+      : "This round takes nothing away — a free breath."),
+    newbits:"The table says this can be done in <b>"+v.L+" line"+(v.L>1?"s":"")+
+            "</b>. You have "+Math.min(8,v.L+2)+"."
+  };
+}
+
+/* ============================================================
    Game
    ============================================================ */
 const $=s=>document.querySelector(s);
@@ -731,23 +828,28 @@ const G={
   anim:null, playing:false, tested:false, best:0, seedBase:0
 };
 
-function stage(){ return STAGES[G.stage]; }
+function stage(){
+  if(G.deep) return G.deepStage || (G.deepStage=deepRound(G.deep));
+  return STAGES[G.stage];
+}
 function trialBoards(){
   const s=stage(), out=[];
-  for(let i=0;i<s.trial;i++) out.push(s.gen(1000+G.stage*7919+i));
+  const salt=G.deep?90000+G.deep*104729:G.stage*7919;
+  for(let i=0;i<s.trial;i++) out.push(s.gen(1000+salt+i));
   return out;
 }
 let BOARDS=[];
 
 /* ---------- persistence ---------- */
 function save(){
-  try{ localStorage.setItem(SAVE,JSON.stringify({stage:G.stage,prog:G.prog})); }catch(e){}
+  try{ localStorage.setItem(SAVE,JSON.stringify({stage:G.stage,prog:G.prog,deep:G.deep||0,golf:G.golf||{}})); }catch(e){}
 }
 function load(){
   try{
     const d=JSON.parse(localStorage.getItem(SAVE)||"null");
     if(d&&typeof d.stage==="number"&&Array.isArray(d.prog)){
       G.stage=Math.min(d.stage,STAGES.length-1); G.prog=d.prog;
+      G.deep=d.deep||0; G.golf=d.golf||{};
       return true;
     }
   }catch(e){}
@@ -1040,6 +1142,20 @@ function onRun(){
 /* ---------- stage flow ---------- */
 function pips(){
   const p=$("#pips"); p.innerHTML="";
+  if(G.deep){
+    const d=document.createElement("div");
+    d.className="depth"; d.textContent="▼ "+G.deep;
+    d.title="depth "+G.deep;
+    p.appendChild(d);
+    const s=stage();
+    if(s.par){
+      const q=document.createElement("div");
+      q.className="parchip"; q.textContent=s.par+" lines is enough";
+      q.title="the shortest rulebook that beats this handicap";
+      p.appendChild(q);
+    }
+    return;
+  }
   STAGES.forEach((s,i)=>{
     const d=document.createElement("div");
     d.className="pip"+(i<G.stage?" done":(i===G.stage?" cur":""));
@@ -1047,8 +1163,9 @@ function pips(){
   });
 }
 function stageCleared(){
-  const s=stage(), last=G.stage>=STAGES.length-1;
+  const s=stage(), last=!G.deep&&G.stage>=STAGES.length-1;
   const lines=G.prog.map(r=>"<li>"+(r.when==="ALWAYS"?"":"when ")+"<b>"+C[r.when].text+"</b> → "+A[r.then].text+"</li>").join("");
+  if(G.deep){ deepCleared(s); return; }
   card(
     "<h2>"+(last?"Everywhere":"It holds")+"</h2>"+
     '<p class="sub">'+s.name+" — "+s.trial+" of "+s.trial+"</p>"+
@@ -1070,13 +1187,37 @@ function stageCleared(){
         '<a href="https://www.gptgames.dev/" style="color:var(--accent);text-decoration:none">gptgames.dev</a></p>' 
       : "<p>"+STAGES[G.stage+1].blurb+"</p>"+
         '<div class="new">'+STAGES[G.stage+1].newbits+"</div>"),
-    last?"Play again from the start":"Take on "+(last?"":STAGES[G.stage+1].name),
+    last?"Go down into The Deep":"Take on "+(last?"":STAGES[G.stage+1].name),
     ()=>{
-      if(last){ G.stage=0; G.prog=[]; }
+      if(last){ G.deep=1; G.deepStage=null; }
       else { G.stage++; }
       BOARDS=[]; G.tested=false; G.showing=null; G.results=[];
       startStage();
     }
+  );
+}
+function deepCleared(s){
+  const used=G.prog.length, par=s.par;
+  G.golf=G.golf||{};
+  const prevBest=G.golf[s.round];
+  if(prevBest===undefined||used<prevBest) G.golf[s.round]=used;
+  const verdict = used<par
+    ? "<b>In "+used+" lines.</b> That is shorter than the shortest this game knew about — please tell someone."
+    : used===par
+      ? "<b>In "+used+" line"+(used>1?"s":"")+", which is the shortest there is.</b> Exhaustive search agrees with you."
+      : "<b>In "+used+" lines.</b> It can be done in "+par+".";
+  const lines=G.prog.map(r=>"<li>"+(r.when==="ALWAYS"?"":"when ")+"<b>"+C[r.when].text+"</b> → "+A[r.then].text+"</li>").join("");
+  card(
+    "<h2>Round "+s.round+" holds</h2>"+
+    '<p class="sub">The Deep · 200 of 200</p>'+
+    "<p>"+verdict+"</p><ul>"+lines+"</ul>",
+    "Deeper",
+    ()=>{ G.deep=s.round+1; G.deepStage=null;
+          BOARDS=[]; G.tested=false; G.showing=null; G.results=[];
+          startStage(); },
+    "Back to the ladder",
+    ()=>{ G.deep=0; G.deepStage=null; G.stage=STAGES.length-1; G.prog=[];
+          BOARDS=[]; G.tested=false; G.results=[]; startStage(); }
   );
 }
 function startStage(){
@@ -1139,7 +1280,7 @@ function howto(){
     "<li>Stepping into a wall <b>kills the run</b>. So does going round for ever.</li>"+
     "<li>You win a stage when one rulebook solves <b>every maze</b> in the proving ground.</li>"+
     "</ul>"+
-    "<p>Click any maze in the proving ground to watch your rule run on it. Drag a line to move it.</p>",
+    "<p>Click any maze in the proving ground to watch your rule run on it. Drag a line to move it.</p>"+"<p>Past the eighth stage is <b>The Deep</b>: endless rounds that each take some of your senses or actions away. Every one has been checked to be solvable before it is handed to you, and it tells you in how many lines.</p>",
     "Back to it", null, null, null, true
   );
 }
@@ -1172,7 +1313,7 @@ function boot(){
     card("<h2>Start over?</h2><p>This clears your progress and your rulebook.</p>",
       "Yes, from the top",()=>{
         try{localStorage.removeItem(SAVE);}catch(e){}
-        G.stage=0; G.prog=[]; BOARDS=[]; startStage();
+        G.stage=0; G.prog=[]; G.deep=0; G.deepStage=null; G.golf={}; BOARDS=[]; startStage();
       },"Keep playing");
   };
   window.addEventListener("resize",()=>{ drawMain(); paintThumbsIdle(); });
@@ -1183,8 +1324,10 @@ function boot(){
     if(e.key==="Enter"&&!e.repeat&&!open){ e.preventDefault(); onRun(); }
   });
   const had=load();
-  if(had&&G.prog.length){ startStage(); }
-  else { G.prog=[]; startStage(); intro(); }
+  /* the opening card is for a first visit only: coming back to an empty
+     rulebook part-way down the ladder is not the same as never having played */
+  if(had&&(G.prog.length||G.stage>0||G.deep)){ startStage(); }
+  else { G.prog=[]; G.stage=0; G.deep=0; startStage(); intro(); }
   (function spin(){ if(!G.playing) drawMain(); requestAnimationFrame(spin); })();
 }
 boot();


### PR DESCRIPTION
…ability table

The ladder was six stages and about twenty minutes. Growing it turned out to be gated entirely by verification, and most of the obvious directions died:

  - harder mazes do nothing (200/200 at 25x25, and with a random start)
  - an efficiency score is dead (all 90 universal rulebooks average 38.6-38.8 steps; there is no spread to compete over)
  - one-way doors, ice and spinner tiles each break the maze rule badly but have no rulebook up to five lines, even given a matching new sense

What works is subtraction. Keep the mazes and shrink the vocabulary, and answers keep existing at greater lengths. Two of those ship as stages:

  The Stone    only wall-senses, no "open ahead"   5 lines
  The Ratchet  every sense back, but no left turn  6 lines

That generalises, and the generalisation is the real addition. A stage is a subset of the vocabulary; there are 1,023; and solvability is monotone, so a subset's answer bounds every superset's. Processing smallest-first and inheriting bounds computes the whole table in 19 seconds: 163 vocabularies can solve a maze at all, with shortest rulebooks of 3, 4, 5 and 6 lines. The table ships as one digit per vocabulary — lengths only, never answers — and The Deep draws endless rounds from it, so every handicap is known to be beatable before it is offered and can tell you in how many lines.

The table only became affordable after an allocation-free reimplementation of the machine, about thirty times faster and checked against the shipped engine over 480,000 runs with zero disagreements. That check earned its keep: the first version disagreed on 0.17% of runs because the condition indices were mapped in the wrong order. The promise is verified against the boards the game actually generates — 200 Deep rounds re-checked on their own 200 mazes each.

Also fixed: returning to a saved game with an empty rulebook showed the first-visit intro even part-way down the ladder.


Claude-Session: https://claude.ai/code/session_01R3342xtS9c4mwwoxUeGShU