### PR TITLE
Fresh Oil: two decisions and a throw

### DIFF
--- a/games/fresh_oil.html
+++ b/games/fresh_oil.html
@@ -80,7 +80,7 @@
   #throw{background:#22304a;border-color:#3a4c6e;padding:8px 18px}
 
   /* ---- gesture hint ---- */
-  #padHint{position:fixed;left:50%;transform:translateX(-50%);bottom:82px;z-index:5;
+  #padHint{position:fixed;left:50%;transform:translateX(-50%);bottom:104px;z-index:5;
     font:600 11px/1 var(--mono);color:var(--faint);letter-spacing:.14em;pointer-events:none;
     text-transform:uppercase;transition:opacity .2s}
 
@@ -109,7 +109,8 @@
   .pick button.sel small{color:var(--dim)}
 
   @media (max-width:700px){
-    #ctl{padding:0 4px 6px;gap:5px}
+    /* keep the throw button clear of the floating logo in the corner */
+    #ctl{padding:0 46px 6px 4px;gap:5px}
     #bar{gap:4px}
     .grp{padding:3px;border-radius:6px}
     .grp .lab{padding:0 3px 0 2px;font-size:8px;letter-spacing:.04em}
@@ -1526,7 +1527,7 @@ const GAME = {
   pattern: null, players: [], turn: 0, frame: 0, standing: [],
   phase: 'title', feet: 22, arrow: 10, speed: 7.9, turn2: 0.5,
   lastShot: null, lastStrikeBall: null, seed: 1, shots: 0, myBall: BALLS[1], flickQuality: undefined,
-  hintHigh: 0, hintLow: 0, hintCorner: 0, fine: false,
+  hintHigh: 0, hintLow: 0, hintCorner: 0, fine: false, hook: 2,
 };
 
 function newPlayer(name, human, cfg) {
@@ -1546,7 +1547,7 @@ function startNight(seed, ballChoice) {
   GAME.turn = 0; GAME.frame = 0; GAME.standing = [1,2,3,4,5,6,7,8,9,10];
   GAME.lastShot = null; GAME.lastStrikeBall = null; GAME.hintHigh = 0; GAME.hintLow = 0; GAME.hintCorner = 0;
   GAME.feet = ballChoice.feet; GAME.arrow = ballChoice.arrow;
-  GAME.speed = 7.9; GAME.turn2 = 0.5; GAME.shots = 0;
+  GAME.hook = 2; GAME.speed = HOOKS[2][1]; GAME.turn2 = HOOKS[2][2]; GAME.shots = 0;
   beginTurn();
   setCamera('aim', true);
   sayLine('Fresh oil. Forty feet, and nobody has thrown on it yet.');
@@ -2154,11 +2155,11 @@ function drawRead() {
   // the ball you read the lane from is the one at a full rack
   const L = GAME.lastStrikeBall;
   const want = targetBoard(GAME.standing);
-  let h = '<div class="k">YOUR LINE</div>' +
-    '<b>feet ' + GAME.feet + '</b> &rsaquo; <b>arrow ' + GAME.arrow.toFixed(1) + '</b>' +
-    '<br><span class="k">arrive at board</span> <b>' + want.toFixed(1) + '</b>' +
+  let h = '<div class="k">YOUR SHOT</div>' +
+    '<span class="k">aiming at board</span> <b>' + GAME.arrow.toFixed(1) + '</b>' +
+    '<br><span class="k">needs to arrive at</span> <b>' + want.toFixed(1) + '</b>' +
     (GAME.standing.length < 10 && GAME.standing.length <= 2 &&
-     !GAME.standing.includes(1) ? '<br><span class="k">less hand, more speed</span>' : '');
+     !GAME.standing.includes(1) ? '<br><span class="k">try less hook</span>' : '');
   el.innerHTML = h;
   el.appendChild(diag);
   const d = document.createElement('div');
@@ -2247,8 +2248,8 @@ function shotLine(r, got) {
   }
   const corner = r.left.length === 1 && (r.left[0] === 7 || r.left[0] === 10);
   if (corner && GAME.hintCorner++ < 1)
-    return 'Left ' + leaveName(r.left) + '. <i>A corner pin is a straight ball: take your hand out of it, ' +
-      'stand left and aim right.</i>';
+    return 'Left ' + leaveName(r.left) + '. <i>A corner pin is a straight ball: turn the hook down ' +
+      'and move the line toward the pin.</i>';
   const hi = L.entryBoard > 19.5, lo = L.entryBoard < 15.5;
   let why = '';
   if (hi) why = ' In at ' + L.entryBoard.toFixed(0) + ' &mdash; high. It is hooking earlier than it was.' +
@@ -2274,11 +2275,13 @@ function oppLine(pl, res, got) {
 
 
 // ---- controls ----
-// Board numbers count from the right edge, so board 20 is LEFT of board 10 —
-// which made every arrow button on the old bar point one way and move the ball
-// the other. Nothing here is phrased in board numbers any more: an arrowhead
-// always means "move the line that way on the screen", and where a control is
-// an amount rather than a direction it gets a minus and a plus instead.
+// There are only two decisions in a bowling shot: where to send it, and how
+// much you want it to come back. Speed and hand are not independent knobs to a
+// person who is not already a bowler — they are two ends of the same decision,
+// so they sit on one axis here and the real pair is behind the ⋯ button for
+// anyone who wants to break the diagonal. Board numbers count from the RIGHT
+// edge of the lane, so nothing in this bar is phrased in them: an arrowhead
+// always means "move the line that way on the screen".
 const SPEEDS = [7.0, 7.3, 7.6, 7.9, 8.2, 8.5];
 const TURNS = [['straight up', 0.0], ['a little', 0.25], ['medium', 0.5], ['around it', 0.75], ['all of it', 1.0]];
 function turnName(t) {
@@ -2288,9 +2291,31 @@ function turnName(t) {
 }
 const mph = v => (v * 2.2369).toFixed(1);
 
+// One axis, from "fast and straight" to "slow and all of it". Down this
+// diagonal is every release a bowler actually picks between; the corner-pin
+// advice — take your hand out of it and throw it firm — is simply HOOK 0.
+const HOOKS = [
+  ['straight', 8.5, 0.00],
+  ['small',    8.2, 0.25],
+  ['normal',   7.9, 0.50],
+  ['big',      7.6, 0.75],
+  ['huge',     7.3, 1.00],
+];
+function hookName() {
+  // if the fine controls have been used to step off the diagonal, say so
+  const h = HOOKS[GAME.hook];
+  if (!h || Math.abs(h[1] - GAME.speed) > 0.02 || Math.abs(h[2] - GAME.turn2) > 0.01) return 'custom';
+  return h[0];
+}
+function setHook(i) {
+  GAME.hook = clamp(i, 0, HOOKS.length - 1);
+  GAME.speed = HOOKS[GAME.hook][1];
+  GAME.turn2 = HOOKS[GAME.hook][2];
+}
+
 // dir: +1 moves the line left on screen, -1 right. One press is the oldest
 // adjustment in bowling — two boards with the feet, one with the eyes — so the
-// single control that matters is the single move the game is about.
+// one control that matters is the one move the game is about.
 function moveLine(dir) {
   GAME.feet = clamp(GAME.feet + 2 * dir, 6, 38);
   GAME.arrow = clamp(GAME.arrow + dir, 2, 32);
@@ -2318,19 +2343,21 @@ function layoutBar() {
     '<button class="val"' + (w ? ' style="min-width:' + w + 'px"' : '') + '>' + val + '</button>' +
     '<button data-a="' + a + '-up" aria-label="more ' + lab + '">+</button></div>';
 
-  let h = lr('LINE', 'line',
-    tight ? GAME.arrow.toFixed(0)
-          : GAME.feet + '<span style="color:var(--faint)">&nbsp;&rsaquo;&nbsp;</span>' + GAME.arrow.toFixed(1),
-    tight ? 30 : 62);
+  // two controls and a throw. everything else is optional.
+  let h = lr('AIM', 'line', GAME.arrow.toFixed(0), tight ? 32 : 40) +
+          pm('HOOK', 'hook', hookName(), tight ? 56 : 66);
   if (GAME.fine) h += lr(tight ? 'FT' : 'FEET', 'feet', GAME.feet) +
-                      lr(tight ? 'AIM' : 'ARROW', 'arrow', GAME.arrow.toFixed(1));
-  h += pm(tight ? 'SPD' : 'SPEED', 'spd', mph(GAME.speed)) +
-       pm('HAND', 'turn', turnName(GAME.turn2), tight ? 58 : 74) +
-       '<div class="grp"><button data-a="fine" aria-label="fine adjustment"' +
+                      lr(tight ? 'EYE' : 'TARGET', 'arrow', GAME.arrow.toFixed(1)) +
+                      pm(tight ? 'SPD' : 'SPEED', 'spd', mph(GAME.speed)) +
+                      pm('HAND', 'turn', turnName(GAME.turn2), tight ? 58 : 74);
+  h += '<div class="grp"><button data-a="fine" aria-label="show speed and hand separately"' +
          (GAME.fine ? ' style="color:var(--amber);border-color:var(--amber)"' : '') + '>&#8943;</button>' +
        '<button id="throw" data-a="throw">THROW</button></div>';
   bar.innerHTML = h;
-  $('padHint').textContent = 'drag the lane to move the line \u00b7 flick up to throw';
+  // the hint sits just above the bar, so it steps aside when the bar grows
+  $('padHint').textContent = GAME.fine ? ''
+    : tight ? 'drag to aim \u00b7 flick up to throw'
+            : '\u2190 \u2192 aim \u00b7 \u2191 \u2193 hook \u00b7 space to throw';
 }
 
 function act(a) {
@@ -2338,6 +2365,8 @@ function act(a) {
   switch (a) {
     case 'line-L': moveLine(1); break;
     case 'line-R': moveLine(-1); break;
+    case 'hook-up': setHook(GAME.hook + 1); break;
+    case 'hook-dn': setHook(GAME.hook - 1); break;
     case 'feet-L': shiftFeet(1); break;
     case 'feet-R': shiftFeet(-1); break;
     case 'arrow-L': shiftArrow(1); break;
@@ -2362,7 +2391,7 @@ addEventListener('keydown', e => {
   const k = e.key.toLowerCase();
   // left is left, up is faster, and the fine adjustments sit on the brackets
   const map = { arrowleft: 'line-L', arrowright: 'line-R', a: 'line-L', d: 'line-R',
-    arrowup: 'spd-up', arrowdown: 'spd-dn', w: 'spd-up', s: 'spd-dn',
+    arrowup: 'hook-up', arrowdown: 'hook-dn', w: 'hook-up', s: 'hook-dn',
     q: 'turn-dn', e: 'turn-up', '[': 'feet-L', ']': 'feet-R',
     ',': 'arrow-L', '.': 'arrow-R', ' ': 'throw' };
   if (map[k] !== undefined) { e.preventDefault(); audio(); act(map[k]); }
@@ -2425,14 +2454,16 @@ function showTitle() {
       '<p>The pocket is <b>board 17½</b>, and the ball wants to arrive there at <b>four to six degrees</b>. ' +
       'Getting it there is the whole game: the ball skids on the oil, grips where the oil ends, and turns back. ' +
       'Every ball thrown on this lane &mdash; yours and theirs &mdash; takes a little of that oil away.</p>' +
-      '<ul><li><b>Line</b> &#9664;&#9654; is the whole game. One press moves you the way bowlers move &mdash; ' +
-      'two boards with the feet, one with the eyes &mdash; in the direction the arrow points. ' +
-      'Drag the lane to do the same thing with your finger.</li>' +
-      '<li>The readout tells you which board the ball actually arrived on. ' +
-      'Arriving <b>past 17½</b> means it hooked too early: move <b>left</b>. Short of 17½, move <b>right</b>.</li>' +
-      '<li><b>Speed</b> buys time: faster skids longer and hooks less. <b>Hand</b> is how far you come around it. ' +
-      '<b>⋯</b> opens feet and target separately, if you want to change the angle rather than the line.</li>' +
+      '<p>You get two decisions. <b>Aim</b> &#9664;&#9654; moves your whole line across the lane &mdash; ' +
+      'the way the arrow points &mdash; and <b>hook</b> &minus;&#8239;+ is how hard the ball comes back. ' +
+      'Then throw it. That is all of it: drag the lane to aim, space to throw.</p>' +
+      '<ul><li>The readout tells you which board the ball actually arrived on. ' +
+      'Arriving <b>past 17½</b> means it hooked too early &mdash; aim <b>left</b>. ' +
+      'Short of 17½, aim <b>right</b>.</li>' +
+      '<li>Corner pins are a straight ball: hook down, aim at the pin.</li>' +
       '<li>Nothing you can do stops the lane changing. Keep moving with it.</li></ul>' +
+      '<p class="sub">⋯ splits hook back into the real speed and hand, and your feet from your target, ' +
+      'if you would rather bowl in those.</p>' +
       '<p class="sub">Pick a ball:</p><div class="pick">' +
       BALLS.map((b, i) => '<button data-b="' + i + '"' + (i === chosen ? ' class="sel"' : '') + '>' +
         b.name + '<small>' + b.blurb + '</small></button>').join('') + '</div>' +


### PR DESCRIPTION
Speed and hand are not independent knobs to anyone who is not already a bowler. They are two ends of one decision — how much you want the ball to come back — and every release a bowler actually chooses between lies on that diagonal: fast and straight at one end, slow with all of it at the other. So they are one control now, HOOK, five steps from "straight" to "huge", and the bar is down to what a shot actually consists of: AIM ◀ ▶, HOOK − +, THROW.

The corner-pin advice falls out of it rather than needing its own vocabulary — "take your hand out of it and throw it firm" is just hook down — and the coach lines say so in those words.

Nothing is gone: ⋯ still splits hook back into real speed and hand, and your feet from your target, for anyone who would rather bowl in those. Arrow keys are now the two decisions and nothing else: ← → aim, ↑ ↓ hook, space to throw, said so on a hint line above the bar. The readout drops "feet 28 › arrow 12" for "aiming at board 12, needs to arrive at 17.5", which is the same two numbers without asking you to know what an arrow is first.

Also: the throw button no longer lands under the floating logo on a phone.


Claude-Session: https://claude.ai/code/session_01Vy6NeyTqFbSLYqgvPHBieZ