### PR TITLE
Blind Crest: give the car a heading, and stop making every corner a b…

### DIFF
--- a/IDEAS.md
+++ b/IDEAS.md
@@ -204,6 +204,39 @@ mistake in a second place made the roadside banks start five segments out, givin
 that slid away as you approached and read as walls appearing and vanishing; the fix is to run the
 strip to the camera and clamp the exploding near vertices off-screen rather than dropping them.
 
+**A car that is moved sideways is not a car that is driven.** The original model took the input as
+lateral acceleration: the road curved underneath and you slid across it, never pointing the car
+anywhere. It plays as lane-shifting and reads to a player as the game steering for them. Giving the
+car a heading of its own — steering turns the wheels, the car follows where it points, the road
+turns underneath at its own rate, all in road-relative coordinates — is maybe thirty lines and is
+the difference between a driving game and a dodging game. Two traps inside it:
+
+*Clamping the steering angle after applying it silently makes steering binary.* Capping `delta` to
+what grip allows looks equivalent to limiting the turn and is not: above about a tenth of lock,
+every input at speed clamps to the same angle, so the whole upper range of the control does
+nothing. Take the input as a **fraction of available grip** and convert that to an angle instead —
+then half a thumb is always half a turn, at any speed.
+
+*Yaw rate is proportional to speed, which is true and unplayable.* A car crawling at walking pace
+genuinely cannot be pointed, so a driver who has slowed right down gets stuck facing the wrong way.
+A small constant added to the speed term (`(v+3)`) costs nothing above 30 km/h and removes the trap.
+
+**Constant off-road drag larger than your acceleration is a permanent trap, and only a long run
+finds it.** The verge applied a flat 13.5 m/s² while full throttle from a standstill gives 10.4, so
+a car that stopped on the grass could never move again — stranded, with a stage restart the only
+escape. It survived every short test and only showed up as one seed in eight sitting at zero for
+**712 seconds** in a long bot run; the tell in the logs was a run whose time was the step cap.
+Make verge drag a rolling resistance (`2.0 + 0.30v`), and add a backstop that recovers anything
+stationary off-road for a couple of seconds. **Any "stuck" state a physics model can reach, a
+player will reach.**
+
+**Stability and the reason to listen are the same dial, so sweep them together.** Damping the
+car's heading deviation makes it far more forgiving — offs at a human reaction lag went 0.94 →
+0.11 → 0.00 as damping rose — but a car stable enough survives arriving too fast, and the value of
+being told about the corner collapsed with it (median gain 5.4s → 5.1s → **1.5s**). Neither number
+alone picks a value; measuring both against the same parameter picks 1.3 immediately. Worth doing
+whenever a comfort fix touches the thing the game is about.
+
 **Periodic shimmer is invisible in a screenshot and easy to measure.** Two surfaces alternated
 colour per-segment — the tarmac every four segments and the kerbs every one — which at 150 km/h is
 a 1.7 Hz and a 7 Hz pulse: slow enough to see, fast enough to irritate, and completely absent from

--- a/games/blind_crest.html
+++ b/games/blind_crest.html
@@ -93,7 +93,7 @@ body.touch #touch{display:block}
 body.touch #hints{display:block}
 #hints .z{position:absolute;bottom:10%;top:36%;
   border:1px dashed rgba(255,255,255,.16);border-radius:10px}
-#hL{left:2%;width:34%}#hM{left:38%;width:24%}#hR{right:2%;width:34%}
+#hL{left:2%;width:41%}#hM{left:44%;width:12%}#hR{right:2%;width:41%}
 #hints .t{position:absolute;left:0;right:0;text-align:center;line-height:1.5;
   font-size:9px;padding:0 4px}
 #hints b{display:block;font-size:17px;color:rgba(255,255,255,.6);font-weight:700}
@@ -123,12 +123,12 @@ body.touch #hints{display:block}
 
   <div id="touch"></div>
   <div id="hints">
-    <div class="z" id="hL"><div class="t" style="top:12%"><b>&larr;</b>further out,<br>more lock</div></div>
+    <div class="z" id="hL"><div class="t" style="top:12%"><b>&larr;</b>nearer the edge,<br>sharper the turn</div></div>
     <div class="z" id="hM">
       <div class="half"><div class="t" style="top:18%"><b>&uarr;</b>lift</div></div>
       <div class="half"><div class="t" style="top:18%"><b>&darr;</b>brake</div></div>
     </div>
-    <div class="z" id="hR"><div class="t" style="top:12%"><b>&rarr;</b>further out,<br>more lock</div></div>
+    <div class="z" id="hR"><div class="t" style="top:12%"><b>&rarr;</b>nearer the edge,<br>sharper the turn</div></div>
   </div>
 
   <div class="screen" id="menu">
@@ -137,14 +137,16 @@ body.touch #hints{display:block}
       <p class="sub">You cannot see the corner. She can.</p>
       <div class="rules">
         <b>Pacenotes.</b> Your co-driver reads the road ahead of you. <b>Left 4</b> is a fast
-        left; <b>right 1</b> is a hairpin. Low number, slow corner. <b>Long</b> means it
-        keeps going, <b>tightens</b> means brake more than you want to,
+        left; <b>right 1</b> is a hairpin. Low number, slow corner. A <b>6</b> is flat out
+        and a <b>5</b> is a lift — it is the <b>4</b>s and below you brake for.
+        <b>Long</b> means it keeps going, <b>tightens</b> means brake more than you want to,
         <b>into</b> means there is no straight in between.<br>
         <b>Drive.</b> <span class="k">← →</span> steer &middot; <span class="k">↑</span> throttle
         &middot; <span class="k">↓</span> brake &middot; <span class="k">R</span> restart stage.<br>
-        <b>On a phone</b> the throttle looks after itself. Hold the left or right side to
-        steer — the further out your thumb, the more lock — and the middle band for speed:
-        lower half brakes, upper half lifts off. Two thumbs work at once.<br>
+        <b>On a phone</b> the throttle looks after itself. Hold anywhere on the left or
+        right to steer: the nearer the middle of the screen, the gentler the turn, and the
+        screen edge is full lock. A narrow strip down the centre is speed — lower half
+        brakes, upper half lifts. Two thumbs work at once.<br>
         <b>The rally.</b> Six stages, they get harder, and the night comes in. Times add up.
       </div>
       <div class="row">
@@ -191,8 +193,8 @@ function mulberry(a){
 /* ── constants ───────────────────────────────────────────────────────── */
 const SEG=6;                 // metres per road segment
 const ROADW=4.5;             // half-width of the tarmac, metres
-const GRIP=11.4;             // m/s^2 of lateral grip on tarmac
-const VMAX=54;               // m/s (~194 km/h)
+const GRIP=19.0;             // m/s^2 of lateral grip on tarmac (arcade, ~1.9g)
+const VMAX=50;               // m/s (180 km/h)
 // Camera. The road's on-screen half-width at the bottom of the frame is
 // ROADW*(H-HOR)/(CAM_D*CAM_H); at the original 1.35 / 0.86 that came to 2.3x
 // the screen width, so the near tarmac swallowed the lower half of the frame
@@ -583,7 +585,7 @@ function drawPoly(x1,y1,w1,x2,y2,w2,fill){
 const G={
   seed:'', stageIdx:0, rally:true, nStages:6,
   stage:null, calls:[], look:LOOKS[0],
-  pos:0, x:0, vx:0, v:0, steer:0,
+  pos:0, x:0, vx:0, v:0, steer:0, yaw:0,
   t:0, running:false, finished:false, penalty:0,
   offT:0, shake:0, warnT:0, warnMsg:'',
   results:[], best:null, bestSplits:null, splits:null, delta:null,
@@ -599,7 +601,7 @@ function loadStage(){
   G.stage=makeStage(G.seed, G.stageIdx, diff);
   G.calls=writeNotes(G.stage);
   G.look=LOOKS[G.rally ? Math.min(LOOKS.length-1, G.stageIdx) : 1];
-  G.pos=0; G.x=0; G.vx=0; G.v=0; G.t=0; G.penalty=0; G.offT=0; G.shake=0;
+  G.pos=0; G.x=0; G.vx=0; G.yaw=0; G.v=0; G.t=0; G.penalty=0; G.offT=0; G.shake=0;
   G.finished=false; G.warnT=0;
   for(const c of G.calls) c.spoken=false;
   buildMini();
@@ -680,13 +682,16 @@ function readTouches(e){
   const w=window.innerWidth, h=window.innerHeight;
   let steer=0, brake=false, coast=false;
   for(const t of e.touches){
-    const x=t.clientX, y=t.clientY;
-    if(x < w*0.38){
-      steer=Math.min(steer, -Math.max(0.18, Math.min(1,(w*0.38-x)/(w*0.30))));
-    } else if(x > w*0.62){
-      steer=Math.max(steer,  Math.max(0.18, Math.min(1,(x-w*0.62)/(w*0.30))));
+    // -1 at the far left of the screen, +1 at the far right
+    const u=Math.max(-1, Math.min(1, (t.clientX - w/2)/(w*0.42)));
+    if(Math.abs(u) <= 0.15){
+      // narrow band down the middle is speed, not steering
+      if(t.clientY > h*0.42) brake=true; else coast=true;
     } else {
-      if(y > h*0.42) brake=true; else coast=true;
+      // squared, so a thumb near the middle is a gentle correction and only
+      // the edge of the screen is full lock
+      const m=Math.sign(u)*u*u;
+      if(Math.abs(m) > Math.abs(steer)) steer=m;
     }
   }
   touch.steer=steer; touch.brake=brake; touch.coast=coast;
@@ -739,24 +744,59 @@ function update(dt){
   if(brake)      G.v -= 13.5*dt;
   else if(gas)   G.v += (9.2*(1-G.v/VMAX)+1.2)*dt;
   else           G.v -= 1.4*dt;
-  if(!onRoad)    G.v -= 13.5*dt;   // the verge is not a run-off area
+  // The verge is not a run-off area — but the drag has to be a rolling
+  // resistance, not a constant. A flat 13.5 m/s^2 exceeded what full throttle
+  // gives from a standstill (10.4), so a car that stopped on the grass could
+  // never move again: stuck for good, with only a stage restart to escape.
+  if(!onRoad)    G.v -= (2.0 + 0.30*G.v)*dt;
   G.v=Math.max(0, Math.min(VMAX, G.v));
 
-  // ---- lateral. The road curves under the car; the car can generate at most
-  // GRIP of its own. Arrive too fast and no amount of steering holds the line.
-  const gf = onRoad ? 1 : 0.30;
-  const demand = seg.curve/SEG * G.v * G.v;        // + = road bends right
-  const ax = G.steer*GRIP*gf - demand;
-  G.vx += ax*dt;
-  G.vx *= Math.exp(-2.3*dt);                        // tyre scrub
+  // ---- lateral. The car has a heading of its own now. Steering turns the
+  // front wheels; the car follows where it is pointed, and the road turns
+  // underneath it at its own rate. Before this the input moved the car
+  // sideways without ever pointing it, which is why cornering felt automatic.
+  const gf = onRoad ? 1 : 0.42;
+  const WB = 2.7;                                   // wheelbase, metres
+  const maxLat = GRIP*gf;
+  // The input asks for a FRACTION OF AVAILABLE GRIP, and that is converted
+  // into a steering angle. Steering first and clamping the angle afterwards
+  // looks equivalent and is not: above about a tenth of lock every input
+  // clamps to the same angle at speed, so steering goes binary exactly where
+  // proportional control matters. This way half a thumb is always half a turn.
+  const askLat = G.steer * maxLat;
+  const vEff = Math.max(6, G.v);
+  const lock = 0.50 * (1 - 0.55*Math.min(1, G.v/VMAX));
+  let delta = Math.atan(askLat*WB/(vEff*vEff));
+  delta = Math.max(-lock, Math.min(lock, delta));
+  const roadRate = seg.curve/SEG * G.v;             // how fast the road turns
+  // The +3 is a low-speed assist. Yaw rate is proportional to speed, which is
+  // true of a real car and means a crawling one cannot be pointed at all — so
+  // a driver who has slowed right down gets stuck facing the wrong way.
+  G.yaw += ((G.v+3.0)*Math.tan(delta)/WB - roadRate)*dt;
+  // Damping acts on heading RELATIVE TO THE ROAD, which is zero when you are
+  // following it — so this costs nothing in a steady corner and only pulls
+  // out deviations. Cheap stability.
+  // 1.3 was picked by sweeping it against two measurements at once: offs at a
+  // human reaction lag (0.94 at 0.7, 0.11 here, 0.00 at 1.8) and whether the
+  // co-driver still pays (5.4s, 5.1s, then collapsing to 1.5s at 1.8, because
+  // a car that stable survives arriving too fast and the notes stop mattering).
+  G.yaw *= Math.exp(-1.3*dt);
+  G.yaw = Math.max(-0.5, Math.min(0.5, G.yaw));
+  G.vx  = G.v*Math.sin(G.yaw);                      // sideways speed, for the look
   G.x  += G.vx*dt;
 
   if(!onRoad){ G.offT+=dt; G.shake=Math.min(1, G.shake+dt*3); }
   else { G.offT=0; G.shake=Math.max(0, G.shake-dt*4); }
 
+  // belt and braces: nothing may leave the player stranded
+  if(!onRoad && G.v < 1.2 && G.offT > 2.5){
+    G.penalty+=5; G.x=0; G.vx=0; G.yaw=0; G.v=8; G.offT=0;
+    flash('OFF · +5s', 1.6);
+  }
+
   // beached
   if(Math.abs(G.x)>ROADW*2.0){
-    G.penalty+=5; G.x=0; G.vx=0; G.v=Math.min(G.v,7);
+    G.penalty+=5; G.x=0; G.vx=0; G.yaw=0; G.v=Math.min(G.v,7);
     flash('OFF · +5s', 1.6);
   }
 
@@ -1036,7 +1076,7 @@ function render(){
     const scale=CAM_D/z;
     const yHere=(i===0) ? camY-CAM_H : sg.y;
     proj.push({
-      sx: W/2 + scale*(x - G.x)*FL + shakeX,
+      sx: W/2 + scale*(x - G.x)*FL - G.yaw*0.5*FL + shakeX,
       sy: HOR - scale*(yHere - camY)*FL + shakeY,
       sw: scale*ROADW*FL,
       // smoothstep rather than a power: it flattens out as it reaches the
@@ -1241,7 +1281,7 @@ function drawCar(){
   const body='#22303f', dark='#16202b', glass='#0a1018';
 
   ctx.save();
-  ctx.translate(cx,cy); ctx.rotate(roll*0.55);
+  ctx.translate(cx,cy); ctx.rotate(roll*0.55 + G.yaw*0.55);
 
   // ground shadow, tight under the car
   ctx.fillStyle='rgba(0,0,0,.40)';


### PR DESCRIPTION
…rake zone

You were right on all three counts, and chasing them turned up a trap that could strand the player for good.

Steering. The car is no longer moved sideways — it has a heading. Steering turns the wheels, the car goes where it points, and the road turns underneath at its own rate. That is what "the game turns for you" was: the input never pointed the car at all. Two traps inside the fix. Clamping the steering angle to what grip allows looks equivalent to limiting the turn and is not: above about a tenth of lock every input at speed clamps to the same angle, so steering goes binary exactly where proportional control matters. The input is now a fraction of available grip, converted to an angle, so half a thumb is half a turn at any speed. And yaw rate is proportional to speed, which is true and unplayable — a crawling car cannot be pointed — so there is a small low-speed assist.

Touch. Strength now comes from distance to the middle of the screen and is squared, so near the centre it is a gentle correction and only the screen edge is full lock: 0.11 / 0.33 / 0.73 / 1.00 across the zone. The speed band is a narrow strip down the centre instead of a third of the screen.

Braking. 99% of corners needed you off the throttle — that was a tuning fault, not a genre trait. At 1.9g and a 180 km/h top speed a 6 is flat out and a 5 is a lift; you brake for 4s and below. Braking distances stay above the 30-60 m sight, so the co-driver keeps its job, and the notes now say something useful about fast corners too.

The trap: verge drag was a flat 13.5 m/s2 while full throttle from rest gives 10.4, so a car that stopped on the grass could never move again. One seed in eight sat at zero for 712 seconds. Drag is now a rolling resistance and anything stationary off-road recovers after a couple of seconds.

Picking the stability: damping heading deviation makes the car far more forgiving (offs at 250 ms lag 0.94 -> 0.11 -> 0.00) but a car that stable survives arriving too fast and the notes stop paying (median gain 5.4s -> 5.1s -> 1.5s). Swept against both at once, 1.3 is the point that satisfies each.

Where it lands: notes faster on 32/48 stages, mean gain 4.19 s, 0.00 offs against 0.83 — the strongest the mechanic has measured. Playable at 0.0 offs up to 250 ms of reaction lag, 0.2-0.7 at 400 ms.


Claude-Session: https://claude.ai/code/session_01PvwkJ5VfbtKqFQwot6Loun