### PR TITLE
Strata: make the notebook's recipes actually run

### DIFF
--- a/games/strata.html
+++ b/games/strata.html
@@ -281,7 +281,6 @@ rx(_.WATER,_.SEED, _.PLANT,_.PLANT, 0.080);
 rx(_.WATER,_.SALT, _.BRINE,_.BRINE, 0.400);
 rx(_.WATER,_.METAL,_.WATER,_.RUST,  0.0022);
 rx(_.WATER,_.ASH,  _.SLUDGE,_.SLUDGE,0.060);
-rx(_.WATER,_.SOIL, _.WATER,_.SOIL,   0.0);   // (placeholder, no-op)
 rx(_.ACID,_.STONE, _.ACID, _.SLUDGE,0.130);
 rx(_.ACID,_.SAND,  _.ACID, _.SLUDGE,0.070);
 rx(_.ACID,_.SOIL,  _.ACID, _.SLUDGE,0.130);
@@ -304,7 +303,6 @@ rx(_.ACID,_.CERAMIC,_.ACID,_.SLUDGE,0.030);
 rx(_.ACID,_.CLAY,  _.ACID, _.SLUDGE,0.120);
 rx(_.ACID,_.STEEL, _.ACID, _.SLUDGE,0.120);
 rx(_.WATER,_.STEEL,_.WATER,_.RUST,  0.0006);
-RX.delete(_.WATER*64+_.SOIL); RX.delete(_.SOIL*64+_.WATER);
 
 /* ---------- grid ---------- */
 let GW=224, GH=150, GN=GW*GH;
@@ -588,17 +586,23 @@ function updateCell(i,x,y,c){
   switch(c){
     case E.FIRE:{
       // fire clings to fuel: it only starves where there is nothing to burn
-      let fuel=0;
+      let fuel=0, vent=0;
       for(let b=-1;b<=1;b++)for(let a=-1;a<=1;a++){
         if(!a&&!b) continue;
         const nx=x+a, ny=y+b; if(!inb(nx,ny)) continue;
         const n=g[ny*GW+nx];
+        if(!n) vent++;                                  // only open air is a way out
         if(EL[n].burn){ fuel++;
           if(Math.random()< (n===E.GAS?0.60:n===E.OIL?0.16:n===E.GUNPOWDER?0.55:n===E.TAR?0.06:n===E.PLANT?0.10:0.045))
             { touch[ny*GW+nx]=touch[ny*GW+nx]||touch[i]; setCell(ny*GW+nx,E.FIRE, n===E.PLANT?'Fire took the plant.':undefined); }
         }
       }
-      if(fuel===0){
+      // Fire with no open air beside it does not starve — it bakes, the way
+      // charcoal does under its own smothered fire. Pack fire into the ground and
+      // the rock around it gets hot enough to give: this is what the notebook
+      // means by stone held in fire. Fire in the open is unchanged.
+      const sealed = vent===0;
+      if(fuel===0 && !sealed){
         if(age[i]>18+((Math.random()*26)|0)){ setCell(i, Math.random()<0.5?E.SMOKE:0); return true; }
       } else if(age[i]>240){ setCell(i,E.SMOKE); return true; }
       // rise only into empty space, and lazily, so it stays on its fuel
@@ -657,11 +661,11 @@ function updateCell(i,x,y,c){
     }
   }
 
-  /* --- plant or wood buried under real weight becomes oil --- */
-  if((c===E.PLANT||c===E.WOOD) && age[i]>520 && Math.random()<0.008){
+  /* --- anything in BURY, left under real weight, becomes what it becomes --- */
+  if(BURY[c] && age[i]>520 && Math.random()<0.008){
     let load=0;
-    for(let k=1;k<=9;k++){ if(y-k<0) break; const n=g[(y-k)*GW+x]; if(EL[n].cls===S&&n!==E.PLANT&&n!==E.WOOD) load++; }
-    if(load>=6){ setCell(i,E.OIL,'Buried deep, under the weight of the stone, it turned to oil.'); return true; }
+    for(let k=1;k<=9;k++){ if(y-k<0) break; const n=g[(y-k)*GW+x]; if(EL[n].cls===S&&!BURY[n]) load++; }
+    if(load>=6){ setCell(i,BURY[c][0],BURY[c][1]); return true; }
   }
 
   /* --- movement --- */


### PR DESCRIPTION
Thirteen of the thirty-four materials could not be produced by any means. An exhaustive search — every pair of every known material, run to a fixpoint on the engine itself — reached 21/34, and the notebook advertised each of the broken routes as the recipe.

Three causes, all restored rather than redesigned:

- The BURY table was defined and never read. The only burial code was the hardcoded plant/wood to oil case, so oil worked and charcoal to coal and mud to clay did not. Generalised that block to consult BURY.

- RX.delete(WATER|SOIL) was meant to drop the no-op placeholder above it, but the real water + soil to mud rule shares that key, so it deleted both. Removed the placeholder and the delete; mud is obtainable again.

- heat > 200 was unreachable from fire: fire with no fuel dies after about 31 ticks, and stone painted with fire peaked at 125 across every brush size. Fire with no open air beside it now bakes on the fuelled clock instead of starving, so "stone held in fire until it gives" gives. Fire in the open, in soil or in sand is unchanged and still burns out.

Measured, same script before and after: exhaustive search 21/34 to 33/34; fire buried in stone yields lava in 65/65 worlds against 0/65; one identical sitting goes from 7 materials found to 18.


Claude-Session: https://claude.ai/code/session_0135iGRu9KXzZ6JkpFWC2MMa